### PR TITLE
[tenant-namespace] Fixed missing podSelector

### DIFF
--- a/charts/charts/tenant-namespace/Chart.yaml
+++ b/charts/charts/tenant-namespace/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Chart for setting up a tenants namespace with all the goodies
 name: tenant-namespace
-version: 0.7.0
+version: 0.7.1

--- a/charts/charts/tenant-namespace/templates/simple-restricted-networkpolicy.yaml
+++ b/charts/charts/tenant-namespace/templates/simple-restricted-networkpolicy.yaml
@@ -5,6 +5,7 @@ metadata:
   name: default
   namespace: {{ .Values.magicnamespace.namespace }}
 spec:
+  podSelector: {}
   policyTypes:
   - Ingress
   - Egress


### PR DESCRIPTION
When I was using Helmfile to install the tenant-namespace chart using Helm 3, validation is turned on and breaks the deployment of the chart due to the missing podSelector.  I replicated this issue using `helm template . | kubectl apply --validate=true --dry-run=true -f -` where the validation errors out on the missing field.  The specific section in the docs is here https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#networkpolicyspec-v1-networking-k8s-io.  I believe adding this field will simply match all pods in the current namespace for this policy and it seems like the chart ends up deploying the resource this way.