### PR TITLE
[tenant-namespace] Added generic extra quota spec

### DIFF
--- a/charts/charts/tenant-namespace/templates/resourcequota.yaml
+++ b/charts/charts/tenant-namespace/templates/resourcequota.yaml
@@ -15,3 +15,6 @@ spec:
     requests.memory: {{ .Values.quota.requests.memory }}
     limits.cpu: {{ .Values.quota.limits.cpu }}
     limits.memory: {{ .Values.quota.limits.memory }}
+    {{- range $key, $val := .Values.quota.extraQuota }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}

--- a/charts/charts/tenant-namespace/values.yaml
+++ b/charts/charts/tenant-namespace/values.yaml
@@ -92,6 +92,11 @@ quota:
   requests:
     cpu: 5
     memory: 4Gi
+  extraQuota:
+#    requests.storage: 5Gi
+#    persistentvolumeclaims: 5
+#    foobar.storageclass.storage.k8s.io/requests.storage: 5Gi
+#    foobar.storageclass.storage.k8s.io/persistentvolumeclaims: 5
 
 limitRange:
   limits:


### PR DESCRIPTION
Added the ability to specify extra quota values.  I've tested this on a cluster and it seems to work ok.  I'm not sure about the usage of range with key and value versus using toYaml.  Does the version of the chart need to be bumped or is that handled during the chart build?