### PR TITLE
[tenant-namespace-operator] Switched to helm module in k8s ansible collection

### DIFF
--- a/charts/charts/tenant-namespace-operator/Chart.yaml
+++ b/charts/charts/tenant-namespace-operator/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.1.5-1
+appVersion: 0.1.6-1

--- a/containers/tenant-namespace-operator/Dockerfile
+++ b/containers/tenant-namespace-operator/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   chmod -R ug+rwx ${HOME}/.ansible && \
   helm pull --repo https://pnnl-miscscripts.github.io/charts tenant-namespace --untar && \
   find roles/ -type f -exec md5sum {} \; > /.extrafingerprints && \
-  echo 0.1.5 >> /.extrafingerprints && \
+  echo 0.1.6 >> /.extrafingerprints && \
   md5sum watches.yaml >> /.extrafingerprints
 
 ENTRYPOINT ["/usr/local/bin/entrypoint", "--inject-owner-ref=false"]

--- a/containers/tenant-namespace-operator/Dockerfile
+++ b/containers/tenant-namespace-operator/Dockerfile
@@ -1,30 +1,29 @@
-FROM quay.io/operator-framework/ansible-operator:v0.16.0
+FROM quay.io/operator-framework/ansible-operator:v0.17.0
 
+ARG helm_version=v3.2.0
 USER 0
+RUN \
+  curl -o helm.tar.gz https://get.helm.sh/helm-${helm_version}-linux-amd64.tar.gz && \
+  tar -zxvf helm.tar.gz && \
+  mv linux-amd64/helm /usr/local/bin/helm && \
+  rm -f helm.tar.gz && \
+  rm -rf linux-amd64 && \
+  touch /.extrafingerprints && \
+  chown ${USER_UID}:0 /.extrafingerprints
 
-COPY watches.yaml ${HOME}/watches.yaml
-COPY requirements.yml ${HOME}/requirements.yml
+USER 1001
+WORKDIR ${HOME}
+
+COPY watches.yaml requirements.yml ${HOME}/
 COPY roles/ ${HOME}/roles/
 
 #FIXME forcing ingress newer to work on newer k8s clusters. Fix upstream chart.
-
 RUN \
-  yum clean all && \
-  yum install -y git && \
-  yum clean all && \
-  curl -o /helm.tar.gz https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz && \
-  tar -zxvf /helm.tar.gz && \
-  mv /linux-amd64/helm /usr/bin/helm && \
-  rm -f /helm.tar.gz && \
   ansible-galaxy collection install -r ${HOME}/requirements.yml && \
   chmod -R ug+rwx ${HOME}/.ansible && \
-  helm plugin install https://github.com/databus23/helm-diff --version master && \
-  helm repo add pnnl-miscscripts https://pnnl-miscscripts.github.io/charts && \
-  helm pull pnnl-miscscripts/tenant-namespace --untar && \
-  cd ${HOME} && \
+  helm pull --repo https://pnnl-miscscripts.github.io/charts tenant-namespace --untar && \
   find roles/ -type f -exec md5sum {} \; > /.extrafingerprints && \
   echo 0.1.5 >> /.extrafingerprints && \
   md5sum watches.yaml >> /.extrafingerprints
 
-USER 1001
 ENTRYPOINT ["/usr/local/bin/entrypoint", "--inject-owner-ref=false"]

--- a/containers/tenant-namespace-operator/build/Dockerfile
+++ b/containers/tenant-namespace-operator/build/Dockerfile
@@ -1,0 +1,1 @@
+../Dockerfile

--- a/containers/tenant-namespace-operator/buildenv
+++ b/containers/tenant-namespace-operator/buildenv
@@ -1,1 +1,1 @@
-export PREFIX=0.1.5
+export PREFIX=0.1.6

--- a/containers/tenant-namespace-operator/requirements.yml
+++ b/containers/tenant-namespace-operator/requirements.yml
@@ -1,3 +1,4 @@
 collections:
-  - community.kubernetes
-  - operator_sdk.util
+  - name: community.kubernetes
+    version: ">=0.11.0"
+  - name: operator_sdk.util

--- a/containers/tenant-namespace-operator/roles/tenantnamespace/meta/main.yml
+++ b/containers/tenant-namespace-operator/roles/tenantnamespace/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: license (GPLv2, CC-BY, etc)
 
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -58,3 +58,6 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
+collections:
+- operator_sdk.util
+- community.kubernetes

--- a/containers/tenant-namespace-operator/roles/tenantnamespace/tasks/main.yml
+++ b/containers/tenant-namespace-operator/roles/tenantnamespace/tasks/main.yml
@@ -11,77 +11,57 @@
         name: "{{ meta.name }}-admin"
         labels:
           name: "{{ meta.name }}-admin"
+          miscscripts.pnnl.gov/namespace-type: admin
 
-- tempfile:
-    state: file
-    suffix: .yaml
-  register: temp_filename
-
-- name: Block for file removal
+- name: Set initial defaults. They be overridden.
+  set_fact:
+    merged_values:
+      magicnamespace:
+        tiller:
+          enabled: false
+- name: Load in Flavor values if referenced
   block:
-  - name: Set initial defaults. They be overridden.
+  - name: Fetch referenced flavor
+    k8s_info:
+      api_version: miscscripts.pnnl.gov/v1beta1
+      kind: TenantNamespaceFlavor
+      name: "{{ flavor_ref.name }}"
+    register: flavor
+    # Failures immediately trigger another reconciliation
+    failed_when:
+    - flavor.resources | length == 0
+  - name: Merge in flavor values
     set_fact:
-      merged_values:
-        magicnamespace:
-          tiller:
-            enabled: false
-    no_log: True
-  - name: Load in Flavor values if referenced
-    block:
-    - name: Fetch referenced flavor
-      set_fact:
-        flavor: "{{ lookup('k8s', kind='TenantNamespaceFlavor', api_version='miscscripts.pnnl.gov/v1beta1', resource_name=_miscscripts_pnnl_gov_tenantnamespace_spec.flavorRef.name) }}"
-      no_log: True
-    - name: Merge in flavor values
-      set_fact:
-        merged_values: "{{ merged_values | combine(flavor.spec, recursive=True) }}"
-      no_log: True
-    when:
-    - _miscscripts_pnnl_gov_tenantnamespace_spec.flavorRef is defined
-    - _miscscripts_pnnl_gov_tenantnamespace_spec.flavorRef.kind == "TenantNamespaceFlavor"
-    - _miscscripts_pnnl_gov_tenantnamespace_spec.flavorRef.group == "miscscripts.pnnl.gov"
-  - name: Set value for forced settings
-    set_fact:
-      overrides:
+      merged_values: "{{ merged_values | combine(flavor.resources[0].spec, recursive=True) }}"
+  when:
+  - flavor_ref is defined
+  - flavor_ref.kind == "TenantNamespaceFlavor"
+  - flavor_ref.group == "miscscripts.pnnl.gov"
+- name: Set value for forced settings
+  set_fact:
+    overrides:
+      namespace: "{{ meta.name }}"
+      magicnamespace:
         namespace: "{{ meta.name }}"
-        magicnamespace:
-          namespace: "{{ meta.name }}"
-        ingress:
-          controller:
-            scope:
-              namespace: "{{ meta.name }}"
-  - name: Set values from CR
-    set_fact:
-      merged_values: "{{ merged_values | combine(_miscscripts_pnnl_gov_tenantnamespace_spec, recursive=True) }}"
-    no_log: True
-  - name: Force namespace settings. Can not be overridden.
-    set_fact:
-      merged_values: "{{ merged_values | combine(overrides, recursive=True) }}"
-    no_log: True
-  - name: Copy values to temp file
-    copy:
-      content: "{{ merged_values | to_yaml }}"
-      dest: "{{ temp_filename.path }}"
-    no_log: True
+      ingress:
+        controller:
+          scope:
+            namespace: "{{ meta.name }}"
+- name: Set values from CR
+  set_fact:
+    merged_values: "{{ merged_values | combine(_miscscripts_pnnl_gov_tenantnamespace_spec, recursive=True) }}"
+- name: Force namespace settings. Can not be overridden.
+  set_fact:
+    merged_values: "{{ merged_values | combine(overrides, recursive=True) }}"
 
 #FIXME Consider making a service account specifically for this so it can't cross namespaces as far as it can today
-  - name: Check for differeneces
-    shell: "helm diff upgrade --detailed-exitcode --namespace {{ meta.name }}-admin {{ meta.name }} /tenant-namespace/ -f {{ temp_filename.path }}"
-    register: differ
-    ignore_errors: yes
-    no_log: True
-
-  - name: Run Helm
-    shell: "helm upgrade --install --namespace {{ meta.name }}-admin {{ meta.name }} /tenant-namespace/ -f {{ temp_filename.path }}"
-    register: objs
-    when:
-    - differ.rc != 0
-
-  always:
-  - name: Remove temp file
-    file:
-      path: "{{ temp_filename.path }}"
-      state: absent
+- name: Run Helm
+  helm:
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.name }}-admin"
+    chart_ref: ${HOME}/tenant-namespace
+    values: "{{ merged_values }}"
+  register: objs
 
 - name: Create the k8s user namespace
   k8s:
@@ -93,4 +73,5 @@
         name: "{{ meta.name }}"
         labels:
           name: "{{ meta.name }}"
+          miscscripts.pnnl.gov/namespace-type: user
 

--- a/containers/tenant-namespace-operator/roles/tenantnamespacefin/meta/main.yml
+++ b/containers/tenant-namespace-operator/roles/tenantnamespacefin/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: license (GPLv2, CC-BY, etc)
 
-  min_ansible_version: 2.6
+  min_ansible_version: 2.9
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -58,3 +58,6 @@ galaxy_info:
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,
   # if you add dependencies to this list.
+collections:
+- operator_sdk.util
+- community.kubernetes

--- a/containers/tenant-namespace-operator/roles/tenantnamespacefin/tasks/main.yml
+++ b/containers/tenant-namespace-operator/roles/tenantnamespacefin/tasks/main.yml
@@ -2,9 +2,12 @@
 # tasks file for tenantnamespace
 
 #Check to see release exists. If it doesnt continue on. If it does, delete it.
-- shell: "(! helm get values --namespace {{ meta.name }}-admin {{ meta.name }}) || helm delete --namespace {{ meta.name }}-admin {{ meta.name }}"
+- name: Delete the helm release
+  helm:
+    name: "{{ meta.name }}"
+    namespace: "{{ meta.name }}-admin"
+    state: absent
   register: objs
-  no_log: True
 
 - name: Delete the k8s user namespace
   k8s:

--- a/containers/tenant-namespace-operator/watches.yaml
+++ b/containers/tenant-namespace-operator/watches.yaml
@@ -2,8 +2,8 @@
 - version: v1beta1
   group: miscscripts.pnnl.gov
   kind: TenantNamespace
-  role: /opt/ansible/roles/tenantnamespace
+  role: tenantnamespace
   reconcilePeriod: "60s"
   finalizer:
     name: finalizer.tenantnamespace.miscscripts.pnnl.gov
-    role: /opt/ansible/roles/tenantnamespacefin
+    role: tenantnamespacefin


### PR DESCRIPTION
- Updated to latest community.kubernetes collection
- Switched to relative paths for watches.yaml for easier development
- Added symlink for build/Dockerfile for operator-sdk run --local
- Added collection references to role meta
- Removed helm-diff plugin since helm module checks values and version for changes
- Removed temp file in role as helm module accepts python dict
- Switched to snake case reference to flavor
- Added label for namespace type

As listed above I've symlinked the Dockerfile so the operator sdk can run locally for fast development of the Ansible roles.  I think that symlink can go away when the build scripts for the container can point to a Dockerfile not in the current working directory.  The build script might need a configurable location to look for the `/.extrafingerprints` file as well since a non-root user can't write to `/` without pre-creating the file as root.

I've updated the Dockerfile to drop root when running non-root required commands and skipped adding the miscscripts repository by passing the repository when calling `helm pull`.  The unpacked chart now ends up in the home directory of the operator user which is easier to replicate in a local dev environment.

It looks like the version of the container is being put in the /.extrafingerprints file, should this PR update that version?