### PR TITLE
Updated rpms containers

### DIFF
--- a/containers/rpms-containerd/Dockerfile
+++ b/containers/rpms-containerd/Dockerfile
@@ -11,13 +11,14 @@ ADD rpmmacros /root/.rpmmacros
 RUN --mount=type=secret,id=gpg \
   set -x && \
   cd / && \
-  yum install -y rpm-build cpio createrepo gnupg2 rpm-sign && \
+  yum install -y rpmdevtools cpio createrepo gnupg2 rpm-sign && \
+  rpmdev-setuptree && \
   NEWVER=$(echo "$VERSION" | awk -F. '{print $1 "." $2 "." $3+1}') && \
-  (! curl -f -o /root/rpmbuild/SOURCES/containerd.tar.gz "https://storage.googleapis.com/cri-containerd-release/cri-containerd-$NEWVER.linux-amd64.tar.gz") && \
+  (! curl -f -I "https://storage.googleapis.com/cri-containerd-release/cri-containerd-$NEWVER.linux-amd64.tar.gz") && \
   NEWVER=$(echo "$VERSION" | awk -F. '{print $1 "." $2+1 ".0"}') && \
-  (! curl -f -o /root/rpmbuild/SOURCES/containerd.tar.gz "https://storage.googleapis.com/cri-containerd-release/cri-containerd-$NEWVER.linux-amd64.tar.gz") && \
-  curl -f -o /root/rpmbuild/SOURCES/containerd.tar.gz "https://storage.googleapis.com/cri-containerd-release/cri-containerd-$VERSION.linux-amd64.tar.gz" && \
+  (! curl -f -I "https://storage.googleapis.com/cri-containerd-release/cri-containerd-$NEWVER.linux-amd64.tar.gz") && \
   sed -i "s/^\(Version:\).*$/\1 $VERSION/" /root/rpmbuild/SOURCES/containerd.spec && \
+  spectool -g -R /root/rpmbuild/SOURCES/containerd.spec && \
   cat /root/rpmbuild/SOURCES/containerd.spec && \
   rpmbuild -ba /root/rpmbuild/SOURCES/containerd.spec && \
   mkdir -p rpms && \
@@ -31,7 +32,7 @@ RUN --mount=type=secret,id=gpg \
   cp /root/rpm.pub /rpms/repodata/RPM-GPG-KEY && \
   mkdir tmp1 && \
   pushd tmp1 && \
-  tar -xvf ~/rpmbuild/SOURCES/containerd.tar.gz && \
+  tar -xvf ~/rpmbuild/SOURCES/cri-containerd-$VERSION.linux-amd64.tar.gz && \
   SUM=$(md5sum usr/local/bin/containerd | awk '{print $1}') && \
   popd && \
   mkdir tmp2 && \

--- a/containers/rpms-containerd/containerd.spec
+++ b/containers/rpms-containerd/containerd.spec
@@ -4,16 +4,24 @@
 Summary: ContainerD and friends
 Name: containerd
 Version: @VERSION@
-Release: 1
+Release: 2
 License: APL
 Packager: MISCSCRIPTS
 Group: Development/Tools
-Source: containerd.tar.gz
+
+Source0: https://storage.googleapis.com/cri-containerd-release/cri-containerd-%{version}.linux-amd64.tar.gz
+Source1: https://storage.googleapis.com/cri-containerd-release/cri-containerd-%{version}.linux-amd64.tar.gz.sha256
+
+Requires: container-selinux
+%{?systemd_requires}
+BuildRequires: systemd
+BuildRequires: coreutils
 
 %description
 %{summary}
 
 %prep
+echo "$(cat %{SOURCE1}) %{SOURCE0}" | sha256sum --check
 %setup -c
 
 %build
@@ -37,3 +45,11 @@ ls -l %{buildroot}
 /etc/systemd/system/containerd.service
 /etc/crictl.yaml
 
+%post
+%systemd_post containerd.service
+
+%preun
+%systemd_preun containerd.service
+
+%postun
+%systemd_postun_with_restart containerd.service

--- a/containers/rpms-node-base/Dockerfile
+++ b/containers/rpms-node-base/Dockerfile
@@ -12,9 +12,9 @@ RUN --mount=type=secret,id=gpg \
   mkdir -p rpms/ && \
   yumdownloader --resolv --installroot=/tmp/root --releasever=/ \
     --destdir rpms --setopt cachedir=/tmp/cache \
-    @Base @Core kernel grub2 docker e2fsprogs container-selinux nspr \
-    nss-util openssh-server openssh iptables-services nfs-utils \
-    authconfig && \
+    @Base @Core @anaconda-tools grub2-efi-x64 kernel grub2 docker e2fsprogs \
+    container-selinux nspr nss-util openssh-server openssh iptables-services \
+    nfs-utils authconfig psmisc libibverbs && \
   gpg --import /run/secrets/gpg && \
   gpg --import /root/rpm.pub && \
   rpm --addsign $(find rpms -type f -name '*.rpm') && \

--- a/containers/rpms-openvswitch/Dockerfile
+++ b/containers/rpms-openvswitch/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=secret,id=gpg \
   set -e && \
   yum install -y createrepo createrepo gnupg2 rpm-sign && \
   mkdir -p rpms/ && \
-  yum install -y centos-release-openstack-rocky createrepo && \
+  yum install -y centos-release-openstack-train createrepo && \
   yumdownloader --resolv --destdir rpms openvswitch && \
   gpg --import /run/secrets/gpg && \
   gpg --import /root/rpm.pub && \


### PR DESCRIPTION
- Updated containerd build to use spectool for source downloads
- Updated containerd spec to include integrity checking and systemd macros
- Updated containerd version checks to use HEAD requests against GCS
- Added missing package updates for UEFI nodes
- Added missing libibverbs for Mellanox driver
- Added psmisc for pstree
- Updated to OpenStack Train for openvswitch

This includes an update to the Release version of the containerd spec so that it is considered a new update to yum.