### PR TITLE
[kubeupdater] Added psp and standards from default helm chart

### DIFF
--- a/charts/charts/kubeupdater/.helmignore
+++ b/charts/charts/kubeupdater/.helmignore
@@ -14,8 +14,10 @@
 *.swp
 *.bak
 *.tmp
+*.orig
 *~
 # Various IDEs
 .project
 .idea/
 *.tmproj
+.vscode/

--- a/charts/charts/kubeupdater/templates/_helpers.tpl
+++ b/charts/charts/kubeupdater/templates/_helpers.tpl
@@ -3,8 +3,8 @@
 Expand the name of the chart.
 */}}
 {{- define "kubeupdater.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,21 +12,52 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kubeupdater.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kubeupdater.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubeupdater.labels" -}}
+helm.sh/chart: {{ include "kubeupdater.chart" . }}
+{{ include "kubeupdater.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubeupdater.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubeupdater.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubeupdater.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubeupdater.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/charts/kubeupdater/templates/bin-configmap.yaml
+++ b/charts/charts/kubeupdater/templates/bin-configmap.yaml
@@ -3,10 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "kubeupdater.fullname" . }}
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ template "kubeupdater.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
 data:
   kubeupdater: |
 {{ .Files.Get "bin/kubeupdater" | indent 4 }}

--- a/charts/charts/kubeupdater/templates/daemonset.yaml
+++ b/charts/charts/kubeupdater/templates/daemonset.yaml
@@ -3,10 +3,7 @@ kind: DaemonSet
 metadata:
   name: {{ template "kubeupdater.fullname" . }}
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ template "kubeupdater.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
 spec:
   updateStrategy:
     rollingUpdate:
@@ -15,14 +12,16 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "kubeupdater.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "kubeupdater.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ template "kubeupdater.name" . }}
-        release: {{ .Release.Name }}
+        {{- include "kubeupdater.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -30,8 +29,8 @@ spec:
         - /bin/sh
         - -ec
         - |
-          cat /config/kubeupdater > /host/usr/bin/kubeupdater
-          chmod +x /host/usr/bin/kubeupdater
+          cat /config/kubeupdater > /host-bin/kubeupdater
+          chmod +x /host-bin/kubeupdater
           nsenter -m/proc/1/ns/mnt -- /usr/bin/kubeupdater -i
           while true; do sleep 10000; done
         name: main
@@ -39,33 +38,32 @@ spec:
           privileged: true
           runAsUser: 0
         volumeMounts:
-        - mountPath: /host
-          name: host
-          mountPropagation: Bidirectional
+        - mountPath: /host-bin
+          name: host-bin
         - mountPath: /config
           name: config
         resources:
-{{ toYaml .Values.resources | indent 10 }}
-      serviceAccount: {{ template "kubeupdater.fullname" . }}
+          {{- toYaml .Values.resources | nindent 10 }}
+      serviceAccountName: {{ template "kubeupdater.serviceAccountName" . }}
       hostNetwork: true
       hostPID: true
       hostIPC: true
       volumes:
       - hostPath:
-          path: /
-        name: host
+          path: /usr/bin
+        name: host-bin
       - configMap:
           name: {{ template "kubeupdater.fullname" . }}
         name: config
-    {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/charts/kubeupdater/templates/node-role.yaml
+++ b/charts/charts/kubeupdater/templates/node-role.yaml
@@ -1,13 +1,11 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kubeupdater-node
+  name: {{ template "kubeupdater.fullname" . }}-node
   namespace: kube-system
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ template "kubeupdater.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -18,3 +16,4 @@ rules:
   verbs:
   - get
   - watch
+{{- end }}

--- a/charts/charts/kubeupdater/templates/node-rolebinding.yaml
+++ b/charts/charts/kubeupdater/templates/node-rolebinding.yaml
@@ -1,18 +1,17 @@
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kubeupdater-node
+  name: {{ template "kubeupdater.fullname" . }}-node
   namespace: kube-system
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ template "kubeupdater.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kubeupdater-node
+  name: {{ template "kubeupdater.fullname" . }}-node
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:nodes
+{{- end }}

--- a/charts/charts/kubeupdater/templates/psp.yaml
+++ b/charts/charts/kubeupdater/templates/psp.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "kubeupdater.fullname" . }}
+  labels:
+    {{- include "kubeupdater.labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  allowedHostPaths:
+  - pathPrefix: '/usr/bin'
+    readOnly: false
+  volumes:
+  - 'configMap'
+  - 'hostPath'
+  hostNetwork: true
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+{{- end }}

--- a/charts/charts/kubeupdater/templates/psp.yaml
+++ b/charts/charts/kubeupdater/templates/psp.yaml
@@ -18,6 +18,7 @@ spec:
   volumes:
   - 'configMap'
   - 'hostPath'
+  - 'secret'
   hostNetwork: true
   hostIPC: true
   hostPID: true

--- a/charts/charts/kubeupdater/templates/repo-configmap.yaml
+++ b/charts/charts/kubeupdater/templates/repo-configmap.yaml
@@ -4,10 +4,7 @@ metadata:
   name: kubeupdater
   namespace: kube-system
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ template "kubeupdater.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
 data:
   everything.repo: |
 {{- if hasKey .Values "rawConfig" }}

--- a/charts/charts/kubeupdater/templates/role.yaml
+++ b/charts/charts/kubeupdater/templates/role.yaml
@@ -1,19 +1,14 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: Role
 metadata:
   name: {{ template "kubeupdater.fullname" . }}
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ template "kubeupdater.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: unrestricted-psp
-subjects:
-- kind: ServiceAccount
-  name: {{ template "kubeupdater.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-{{- end -}}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "kubeupdater.fullname" . }}
+{{- end }}

--- a/charts/charts/kubeupdater/templates/rolebinding.yaml
+++ b/charts/charts/kubeupdater/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "kubeupdater.fullname" . }}
+  labels:
+    {{- include "kubeupdater.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "kubeupdater.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "kubeupdater.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/charts/kubeupdater/templates/serviceaccount.yaml
+++ b/charts/charts/kubeupdater/templates/serviceaccount.yaml
@@ -1,11 +1,12 @@
-{{- if .Values.rbac.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ template "kubeupdater.serviceAccountName" . }}
   labels:
-    app: {{ template "kubeupdater.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "kubeupdater.fullname" . }}
-{{- end -}}
+    {{- include "kubeupdater.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/charts/kubeupdater/values.yaml
+++ b/charts/charts/kubeupdater/values.yaml
@@ -14,8 +14,24 @@ image:
   tag: 3.11
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 rbac:
   create: true
+
+podSecurityPolicy:
+  enabled: true
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
- Added PSP
- Updated chart to use labels and service account name generators from default helm chart values
- Updated DaemonSet to only mount /usr/bin instead of /

The label selector changes do break the ability to upgrade in place so maybe that needs a backwards compatibility flag.  Many of the template tags are now missing a trailing dash which I think instructs the template engine to remove whitespace.  I'm not sure why this changed but it seems to still produce the same output.