### PR TITLE
Fixed ipmi-exporter base image

### DIFF
--- a/containers/ipmi-exporter/Dockerfile
+++ b/containers/ipmi-exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM rockylinux:8
 MAINTAINER Kevin Fox <Kevin.Fox@pnnl.gov>
 
 RUN \


### PR DESCRIPTION
Switched to rockylinux