### PR TITLE
Switched to go install for pixiecore

### DIFF
--- a/containers/pixiecore/Dockerfile
+++ b/containers/pixiecore/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang
 
 RUN \
-  CGO_ENABLED=0 go get go.universe.tf/netboot/cmd/pixiecore
+  CGO_ENABLED=0 go install go.universe.tf/netboot/cmd/pixiecore@latest
 
 FROM alpine:3.9
 COPY --from=0 /go/bin/pixiecore /bin/pixiecore


### PR DESCRIPTION
go get for executables was deprecated in Go 1.17 and removed in Go 1.18