### PR TITLE
Updated CRDs to apiext/v1

### DIFF
--- a/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_clustergitlabrunnerflavors_crd.yaml
+++ b/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_clustergitlabrunnerflavors_crd.yaml
@@ -11,6 +11,7 @@ spec:
     plural: clustergitlabrunnerflavors
     singular: clustergitlabrunnerflavor
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1beta1
     schema:

--- a/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_clustergitlabrunnerflavors_crd.yaml
+++ b/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_clustergitlabrunnerflavors_crd.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clustergitlabrunnerflavors.miscscripts.pnnl.gov
@@ -10,13 +11,34 @@ spec:
     plural: clustergitlabrunnerflavors
     singular: clustergitlabrunnerflavor
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterGitlabRunnerFlavor is the Schema for the clustergitlabrunnerflavors API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of ClusterGitlabRunnerFlavor
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of ClusterGitlabRunnerFlavor
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_gitlabrunners_crd.yaml
+++ b/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_gitlabrunners_crd.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: gitlabrunners.miscscripts.pnnl.gov
@@ -10,13 +11,34 @@ spec:
     plural: gitlabrunners
     singular: gitlabrunner
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: GitlabRunner is the Schema for the gitlabrunners API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of GitlabRunner
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of GitlabRunner
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_gitlabrunners_crd.yaml
+++ b/containers/gitlab-runner-operator/deploy/crds/miscscripts.pnnl.gov_gitlabrunners_crd.yaml
@@ -11,6 +11,7 @@ spec:
     plural: gitlabrunners
     singular: gitlabrunner
   scope: Namespaced
+  preserveUnknownFields: false
   versions:
   - name: v1beta1
     schema:

--- a/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaceflavors_crd.yaml
+++ b/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaceflavors_crd.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tenantnamespaceflavors.miscscripts.pnnl.gov
@@ -10,13 +11,34 @@ spec:
     plural: tenantnamespaceflavors
     singular: tenantnamespaceflavor
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TenantNamespaceFlavor is the Schema for the tenantnamespaceflavors API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TenantNamespaceFlavor
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of TenantNamespaceFlavor
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaceflavors_crd.yaml
+++ b/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaceflavors_crd.yaml
@@ -11,6 +11,7 @@ spec:
     plural: tenantnamespaceflavors
     singular: tenantnamespaceflavor
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1beta1
     schema:

--- a/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaces_crd.yaml
+++ b/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaces_crd.yaml
@@ -1,4 +1,5 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tenantnamespaces.miscscripts.pnnl.gov
@@ -10,13 +11,34 @@ spec:
     plural: tenantnamespaces
     singular: tenantnamespace
   scope: Cluster
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TenantNamespace is the Schema for the tenantnamespaces API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of TenantNamespace
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of TenantNamespace
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaces_crd.yaml
+++ b/containers/tenant-namespace-operator/deploy/crds/miscscripts.pnnl.gov_tenantnamespaces_crd.yaml
@@ -11,6 +11,7 @@ spec:
     plural: tenantnamespaces
     singular: tenantnamespace
   scope: Cluster
+  preserveUnknownFields: false
   versions:
   - name: v1beta1
     schema:


### PR DESCRIPTION
Used operator-sdk v1.22.0 to generate CRD examples

Tested with k8s v1.21.13 in minikube.