### PR TITLE
[tenant-namespace-operator] Updated to latest tenant-namespace chart

### DIFF
--- a/charts/charts/tenant-namespace-operator/Chart.yaml
+++ b/charts/charts/tenant-namespace-operator/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.1.12-1
+appVersion: 0.1.13-1

--- a/containers/tenant-namespace-operator/Dockerfile
+++ b/containers/tenant-namespace-operator/Dockerfile
@@ -25,11 +25,11 @@ RUN \
   ansible-galaxy collection install -r ${HOME}/requirements.yml && \
   chmod -R ug+rwx ${HOME}/.ansible && \
   helm plugin install https://github.com/databus23/helm-diff --version master && \
-  helm pull --repo https://pnnl-miscscripts.github.io/charts tenant-namespace --version 0.6.12 --untar && \
+  helm pull --repo https://pnnl-miscscripts.github.io/charts tenant-namespace --version 0.6.13 --untar && \
   cd tenant-namespace/charts/ingress-nginx/ && \
   cd - && \
   find roles/ -type f -exec md5sum {} \; > /.extrafingerprints && \
-  echo 0.1.12 >> /.extrafingerprints && \
+  echo 0.1.13 >> /.extrafingerprints && \
   md5sum watches.yaml >> /.extrafingerprints
 
 ENTRYPOINT ["/usr/local/bin/entrypoint", "--inject-owner-ref=false"]

--- a/containers/tenant-namespace-operator/buildenv
+++ b/containers/tenant-namespace-operator/buildenv
@@ -1,1 +1,1 @@
-export PREFIX=0.1.12
+export PREFIX=0.1.13

--- a/containers/tenant-namespace-operator/requirements.yml
+++ b/containers/tenant-namespace-operator/requirements.yml
@@ -2,3 +2,4 @@ collections:
   - name: community.kubernetes
     version: "<2.0.0"
   - name: operator_sdk.util
+    version: "0.1.0"


### PR DESCRIPTION
* Fixed operator ansible collection dependencies as latest operator_sdk.util breaks k8s_status call

I've tested this in minikube with deploying a new tenant and upgrading an existing tenant from the example cr's in the repo.  The new ingress controller will become the leader and then sleep for a bit and eventually create the new lease object.