### PR TITLE
[rpms-kubernetes9] Migrated to pkgs.k8s.io

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,8 +154,6 @@ jobs:
         run: |
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build rpms-kubernetes 1.22
-          printf "%s" "$RPM_GPG_KEY" > rpm.priv
-          ./containers/build rpms-kubernetes9 1.22
           rm -f rpm.priv
   buildc-rpms-k8s-23:
     runs-on: ubuntu-20.04
@@ -170,8 +168,6 @@ jobs:
         run: |
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build rpms-kubernetes 1.23
-          printf "%s" "$RPM_GPG_KEY" > rpm.priv
-          ./containers/build rpms-kubernetes9 1.23
           rm -f rpm.priv
   buildc-rpms-k8s-24:
     runs-on: ubuntu-20.04
@@ -189,6 +185,20 @@ jobs:
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build rpms-kubernetes9 1.24
           rm -f rpm.priv
+  buildc-rpms-k8s-25:
+    runs-on: ubuntu-20.04
+    needs:
+    - buildc-rpms-node-base
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+      - name: Build rpms-kubernetes container 1.25
+        env:
+          RPM_GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
+        run: |
+          printf "%s" "$RPM_GPG_KEY" > rpm.priv
+          ./containers/build rpms-kubernetes9 1.25
+          rm -f rpm.priv
   buildc-rpms-k8s-21:
     runs-on: ubuntu-20.04
     needs:
@@ -202,8 +212,6 @@ jobs:
         run: |
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build rpms-kubernetes 1.21
-          printf "%s" "$RPM_GPG_KEY" > rpm.priv
-          ./containers/build rpms-kubernetes9 1.21
           rm -f rpm.priv
   buildc-rpms-k8s-28:
     runs-on: ubuntu-20.04
@@ -245,8 +253,6 @@ jobs:
         run: |
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build k8s-node-image 1.22
-          printf "%s" "$RPM_GPG_KEY" > rpm.priv
-          ./containers/build k8s-node-image9 1.22
           rm -f rpm.priv
   build-node-image-23:
     runs-on: ubuntu-20.04
@@ -264,8 +270,6 @@ jobs:
         run: |
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build k8s-node-image 1.23
-          printf "%s" "$RPM_GPG_KEY" > rpm.priv
-          ./containers/build k8s-node-image9 1.23
           rm -f rpm.priv
   build-node-image-24:
     runs-on: ubuntu-20.04
@@ -286,6 +290,23 @@ jobs:
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build k8s-node-image9 1.24
           rm -f rpm.priv
+  build-node-image-25:
+    runs-on: ubuntu-20.04
+    needs:
+    - buildc-rpms-node-base
+    - buildc-rpms-containerd
+    - buildc-rpms-openvswitch
+    - buildc-rpms-k8s-25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+      - name: Build full k8s node image 1.25
+        env:
+          RPM_GPG_KEY: ${{ secrets.RPM_GPG_KEY }}
+        run: |
+          printf "%s" "$RPM_GPG_KEY" > rpm.priv
+          ./containers/build k8s-node-image9 1.25
+          rm -f rpm.priv
   build-node-image-21:
     runs-on: ubuntu-20.04
     needs:
@@ -302,8 +323,6 @@ jobs:
         run: |
           printf "%s" "$RPM_GPG_KEY" > rpm.priv
           ./containers/build k8s-node-image 1.21
-          printf "%s" "$RPM_GPG_KEY" > rpm.priv
-          ./containers/build k8s-node-image9 1.21
           rm -f rpm.priv
   build-node-image-28:
     runs-on: ubuntu-20.04
@@ -343,8 +362,6 @@ jobs:
         uses: actions/checkout@v4.1.0
       - name: Build k8s-node-image+nginx container 1.22
         run: ./containers/build k8s-node-image-nginx 1.22
-      - name: Build k8s-node-image+nginx9 container 1.22
-        run: ./containers/build k8s-node-image-nginx9 1.22
   build-node-image-23-nginx:
     runs-on: ubuntu-20.04
     needs:
@@ -354,8 +371,6 @@ jobs:
         uses: actions/checkout@v4.1.0
       - name: Build k8s-node-image+nginx container 1.23
         run: ./containers/build k8s-node-image-nginx 1.23
-      - name: Build k8s-node-image+nginx9 container 1.23
-        run: ./containers/build k8s-node-image-nginx9 1.23
   build-node-image-24-nginx:
     runs-on: ubuntu-20.04
     needs:
@@ -367,6 +382,15 @@ jobs:
         run: ./containers/build k8s-node-image-nginx 1.24
       - name: Build k8s-node-image+nginx9 container 1.24
         run: ./containers/build k8s-node-image-nginx9 1.24
+  build-node-image-25-nginx:
+    runs-on: ubuntu-20.04
+    needs:
+    - build-node-image-25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.0
+      - name: Build k8s-node-image+nginx9 container 1.25
+        run: ./containers/build k8s-node-image-nginx9 1.25
   build-node-image-21-nginx:
     runs-on: ubuntu-20.04
     needs:
@@ -376,8 +400,6 @@ jobs:
         uses: actions/checkout@v4.1.0
       - name: Build k8s-node-image+nginx container 1.21
         run: ./containers/build k8s-node-image-nginx 1.21
-      - name: Build k8s-node-image+nginx9 container 1.21
-        run: ./containers/build k8s-node-image-nginx9 1.21
   build-node-image-28-nginx:
     runs-on: ubuntu-20.04
     needs:
@@ -401,6 +423,7 @@ jobs:
     - build-node-image-22-nginx
     - build-node-image-23-nginx
     - build-node-image-24-nginx
+    - build-node-image-25-nginx
     - build-node-image-21-nginx
     - build-node-image-28-nginx
     - buildc-pixiecore

--- a/charts/charts/buildall
+++ b/charts/charts/buildall
@@ -37,7 +37,7 @@ for ver in 1-21 1-22 1-23 1-24; do
 	#sed IMAGETAG into README.md
 done
 
-for ver in 1-21 1-22 1-23 1-24 1-28; do
+for ver in 1-24 1-25 1-28; do
 	cp -a k8s-node-image9 k8s-node-image9-$ver
 	sed -i "s@k8s-node-image-nginx9-1-24@k8s-node-image-nginx9-$ver@g" k8s-node-image9-$ver/Chart.yaml k8s-node-image9-$ver/values.yaml
 	sed -i "s@^name:.*@name: k8s-node-image9-$ver@g" k8s-node-image9-$ver/Chart.yaml
@@ -59,7 +59,7 @@ for CHART in nginx-app console chronyd dhcpd ipmi-exporter kubeupdater k8s-node-
 		SUBBUILDS="1-21 1-22 1-23 1-24"
 		;;
 	k8s-node-image9)
-		SUBBUILDS="1-21 1-22 1-23 1-24 1-28"
+		SUBBUILDS="1-24 1-25 1-28"
 		;;
 	*)
 		SUBBUILDS="latest"

--- a/charts/image-library-charts/buildall
+++ b/charts/image-library-charts/buildall
@@ -26,7 +26,7 @@ for CONTAINER in ipmitool ipmi-exporter dhcpd inotify-tools chronyd debug-toolbo
 		SUBBUILDS="1.21 1.22 1.23 1.24"
 		;;
 	k8s-node-image-nginx9)
-		SUBBUILDS="1.21 1.22 1.23 1.24 1.28"
+		SUBBUILDS="1.24 1.25 1.28"
 		;;
 	*)
 		SUBBUILDS="latest"

--- a/containers/rpms-kubernetes9/Dockerfile
+++ b/containers/rpms-kubernetes9/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.0-experimental
+# syntax = docker/dockerfile:1.2
 
 FROM pnnlmiscscripts/rpms-node-base9:latest
 
@@ -13,18 +13,13 @@ ADD rpmmacros /root/.rpmmacros
 
 ADD kubernetes.repo /etc/yum.repos.d/
 RUN --mount=type=secret,id=gpg \
+  sed -i "s/KUBE_VERSION/${SUBBUILD}/" /etc/yum.repos.d/kubernetes.repo && \
   yum install -y 'dnf-command(download)' createrepo gnupg2 rpm-sign findutils && \
   mkdir -p rpms/ && \
-  VERSION=$(yum --showduplicates list kubelet -q | grep -vi packages | grep -vi rc | grep -vi alpha | grep -vi beta | awk '{print $2}' | awk -F. '{print $2}' | sort -nu | tail -n $BACK | head -n 1) && \
-  VERSION="$(echo $SUBBUILD | awk -F. '{print $2}')" && \
-  SUBVERSION=$(yum --showduplicates list kubelet -q | grep -vi packages | awk '{print $2}' | grep "^1\.$VERSION\."| awk -F. '{print $3}' | awk -F- '{print $1}' | sort -nu | tail -n 1) && \
-  REVISION=$(yum --showduplicates list kubelet -q | grep -vi packages | awk '{print $2}' | grep "^1\.$VERSION\.$SUBVERSION-" | awk -F- '{print $2}' | sort -nu | tail -n 1) && \
-  FULLVERSION="1.$VERSION.$SUBVERSION-$REVISION" && \
-  echo "Picked $FULLVERSION" && \
   mkdir -p rpms/ && \
   cd /rpms && \
   cp -a /rpms-base/*.rpm . && \
-  dnf install -y --downloadonly --destdir /rpms "kubelet-$FULLVERSION" "kubeadm-$FULLVERSION" "kubectl-$FULLVERSION" && \
+  dnf install -y --downloadonly --destdir /rpms kubelet kubeadm kubectl && \
   find /rpms-base -maxdepth 1 -type f -name '*.rpm' -printf '%f\n' | while read line; do rm -f $line; done && \
   gpg --import /run/secrets/gpg && \
   gpg --import /root/rpm.pub && \

--- a/containers/rpms-kubernetes9/kubernetes.repo
+++ b/containers/rpms-kubernetes9/kubernetes.repo
@@ -1,8 +1,6 @@
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/vKUBE_VERSION/rpm/
 enabled=1
 gpgcheck=1
-# See issue https://github.com/kubernetes/release/issues/1982
-repo_gpgcheck=0
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg https://packages.cloud.google.com/yum/doc/apt-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/vKUBE_VERSION/rpm/repodata/repomd.xml.key


### PR DESCRIPTION
Added new repo file with version replacement
Kubernetes only published 1.24+ to the new repo
Rocky 9 builds have been migrated to use this new repo