### PR TITLE
[tenant-namespace-operator] Added tmpfs to /tmp in the container

### DIFF
--- a/charts/charts/tenant-namespace-operator/Chart.yaml
+++ b/charts/charts/tenant-namespace-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.20
+version: 0.1.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/charts/tenant-namespace-operator/templates/deployment.yaml
+++ b/charts/charts/tenant-namespace-operator/templates/deployment.yaml
@@ -26,8 +26,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
-          - mountPath: /tmp/ansible-operator/runner
-            name: runner
+            - mountPath: /tmp
+              name: temp
+            - mountPath: /tmp/ansible-operator/runner
+              name: runner
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           resources:
@@ -81,6 +83,10 @@ spec:
             - name: INGRESS_CLUSTERROLE
               value: {{ include "tenant-namespace-operator.fullname" . }}-ic
       volumes:
+        - name: temp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 64Mi
         - name: runner
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/charts/tenant-namespace-operator/templates/deployment.yaml
+++ b/charts/charts/tenant-namespace-operator/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
         - name: temp
           emptyDir:
             medium: Memory
-            sizeLimit: 64Mi
+            sizeLimit: {{ .Values.tmpSizeLimit | quote }}
         - name: runner
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/charts/charts/tenant-namespace-operator/values.yaml
+++ b/charts/charts/tenant-namespace-operator/values.yaml
@@ -22,6 +22,9 @@ debug: false
 # Set operator max concurrent reconciles
 #maxConcurrentReconciles: 16
 
+# EmptyDir /tmp mount size limit
+tmpSizeLimit: 64Mi
+
 image:
   repository: pnnlmiscscripts/tenant-namespace-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
* Helm/Ansible seems to use /tmp when reconciling each CR
* Dramatically decreases Ansible execution time

In my testing, Ansible now takes seconds to execute the operator role.