### PR TITLE
[tenant-namespace] Upgraded to ingress-nginx 1.8.4

### DIFF
--- a/charts/charts/tenant-namespace/Chart.yaml
+++ b/charts/charts/tenant-namespace/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 type: application
 description: Chart for setting up a tenants namespace with all the goodies
 name: tenant-namespace
-version: 0.7.12
+version: 0.7.13
 appVersion: "1.0"
 dependencies:
 - name: magic-namespace
@@ -16,6 +16,6 @@ dependencies:
   repository: "https://pnnl-miscscripts.github.io/charts"
 - name: ingress-nginx
   alias: ingress
-  version: "4.2.3"
+  version: "4.7.3"
   repository: "https://kubernetes.github.io/ingress-nginx"
   condition: ingress.nginx.enabled

--- a/charts/charts/tenant-namespace/templates/nginx-ingress-role.yaml
+++ b/charts/charts/tenant-namespace/templates/nginx-ingress-role.yaml
@@ -32,7 +32,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - "networking.k8s.io" # k8s 1.14+
   resources:
   - ingresses
@@ -41,7 +40,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - extensions
   - "networking.k8s.io" # k8s 1.14+
   resources:
   - ingresses/status
@@ -62,3 +60,11 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
* Added endpoint slice rbac rules
* Removed ingress extensions group, gone since 1.22

This avoids the breaking changes in ingress-nginx 1.9.x for now.