### PR TITLE
[curl-jq] Updated to alpine 3.20

### DIFF
--- a/containers/curl-jq/Dockerfile
+++ b/containers/curl-jq/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.12
+FROM alpine:3.20
 MAINTAINER Kevin Fox <Kevin.Fox@pnnl.gov>
 
 RUN \
   apk add --no-cache --update curl jq bash
 
-ENTRYPOINT /bin/bash
+CMD [ "/bin/bash" ]


### PR DESCRIPTION
* Switched entrypoint shell form to cmd exec form

I was having trouble executing jq due to the entrypoint in shell form.  The two issues i was running into was the cannot execute binary file issue here https://stackoverflow.com/questions/61055324/docker-cannot-execute-binary-file and another issue with the shell treating jq output as shell commands.  Switching to cmd in exec form allows running the container interactively when passed no arguments since it calls `/bin/sh -c /bin/bash`.  When executed with arguments it calls `/bin/sh -c "<container args>"`.