### PR TITLE
Switched to wget for install.img download

### DIFF
--- a/containers/anaconda9/Dockerfile
+++ b/containers/anaconda9/Dockerfile
@@ -1,12 +1,13 @@
 FROM rockylinux:9
 
 RUN \
+  dnf install -y wget && \
   mkdir -p /data/images/pxeboot/ && \
   curl https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/.treeinfo > /data/.treeinfo && \
   curl https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/images/pxeboot/vmlinuz -o /data/images/pxeboot/vmlinuz && \
   curl https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/images/pxeboot/initrd.img -o /data/images/pxeboot/initrd.img && \
   curl https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/images/efiboot.img -o /data/images/efiboot.img && \
-  curl https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/images/install.img -o /data/images/install.img && \
+  wget https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/images/install.img -O /data/images/install.img && \
   curl http://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/LICENSE -o /data/LICENSE && \
   sed -i 's/AppStream,BaseOS/BaseOS/' /data/.treeinfo && \
   curl -s http://download.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/media.repo | grep mediaid | awk -F= '{print $2}' > /data/RockyLinux_BuildTag && \


### PR DESCRIPTION
Based on reading docs, wget should re-connect when the download stalls and can be configured with the `--read-timeout` option.